### PR TITLE
Add PHP productivity dashboard modules

### DIFF
--- a/practice/php_productivity_dashboard/calendar.php
+++ b/practice/php_productivity_dashboard/calendar.php
@@ -1,0 +1,35 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('INSERT INTO events (title, event_date, description) VALUES (:title, :event_date, :description)');
+    $stmt->execute([
+        ':title' => $_POST['title'] ?? '',
+        ':event_date' => $_POST['event_date'] ?? '',
+        ':description' => $_POST['description'] ?? ''
+    ]);
+}
+
+$events = $pdo->query('SELECT * FROM events ORDER BY event_date')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Calendar</title>
+</head>
+<body>
+    <h1>Calendar</h1>
+    <form method="post">
+        <input type="text" name="title" placeholder="Title" required>
+        <input type="date" name="event_date" required>
+        <input type="text" name="description" placeholder="Description">
+        <button type="submit">Add Event</button>
+    </form>
+    <ul>
+        <?php foreach ($events as $event): ?>
+            <li><?php echo htmlspecialchars($event['event_date']); ?> - <?php echo htmlspecialchars($event['title']); ?>: <?php echo htmlspecialchars($event['description']); ?></li>
+        <?php endforeach; ?>
+    </ul>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>

--- a/practice/php_productivity_dashboard/db.php
+++ b/practice/php_productivity_dashboard/db.php
@@ -1,0 +1,52 @@
+<?php
+// Simple SQLite connection and table setup
+$pdo = new PDO('sqlite:' . __DIR__ . '/dashboard.db');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+// Habits table
+$pdo->exec("CREATE TABLE IF NOT EXISTS habits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    frequency TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+)");
+
+// Events table for calendar
+$pdo->exec("CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    event_date TEXT,
+    description TEXT
+)");
+
+// Time entries for timer
+$pdo->exec("CREATE TABLE IF NOT EXISTS time_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task TEXT NOT NULL,
+    minutes INTEGER,
+    entry_date TEXT
+)");
+
+// Goals table
+$pdo->exec("CREATE TABLE IF NOT EXISTS goals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    goal TEXT NOT NULL,
+    deadline TEXT
+)");
+
+// Journal entries
+$pdo->exec("CREATE TABLE IF NOT EXISTS journal_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+)");
+
+// Meetings
+$pdo->exec("CREATE TABLE IF NOT EXISTS meetings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    meeting_date TEXT,
+    meeting_time TEXT,
+    agenda TEXT
+)");
+?>

--- a/practice/php_productivity_dashboard/goals.php
+++ b/practice/php_productivity_dashboard/goals.php
@@ -1,0 +1,33 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('INSERT INTO goals (goal, deadline) VALUES (:goal, :deadline)');
+    $stmt->execute([
+        ':goal' => $_POST['goal'] ?? '',
+        ':deadline' => $_POST['deadline'] ?? ''
+    ]);
+}
+
+$goals = $pdo->query('SELECT * FROM goals ORDER BY deadline')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Goals</title>
+</head>
+<body>
+    <h1>Goals</h1>
+    <form method="post">
+        <input type="text" name="goal" placeholder="Goal" required>
+        <input type="date" name="deadline">
+        <button type="submit">Add Goal</button>
+    </form>
+    <ul>
+        <?php foreach ($goals as $goal): ?>
+            <li><?php echo htmlspecialchars($goal['goal']); ?> <?php if($goal['deadline']) echo '- ' . htmlspecialchars($goal['deadline']); ?></li>
+        <?php endforeach; ?>
+    </ul>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>

--- a/practice/php_productivity_dashboard/habit.php
+++ b/practice/php_productivity_dashboard/habit.php
@@ -1,0 +1,33 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('INSERT INTO habits (name, frequency) VALUES (:name, :frequency)');
+    $stmt->execute([
+        ':name' => $_POST['name'] ?? '',
+        ':frequency' => $_POST['frequency'] ?? ''
+    ]);
+}
+
+$habits = $pdo->query('SELECT * FROM habits ORDER BY id DESC')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Habit Tracker</title>
+</head>
+<body>
+    <h1>Habit Tracker</h1>
+    <form method="post">
+        <input type="text" name="name" placeholder="Habit" required>
+        <input type="text" name="frequency" placeholder="Frequency">
+        <button type="submit">Add Habit</button>
+    </form>
+    <ul>
+        <?php foreach ($habits as $habit): ?>
+            <li><?php echo htmlspecialchars($habit['name']); ?> - <?php echo htmlspecialchars($habit['frequency']); ?></li>
+        <?php endforeach; ?>
+    </ul>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>

--- a/practice/php_productivity_dashboard/index.php
+++ b/practice/php_productivity_dashboard/index.php
@@ -1,0 +1,20 @@
+<?php
+?><!DOCTYPE html>
+<html>
+<head>
+    <title>Productivity Dashboard</title>
+</head>
+<body>
+    <h1>Productivity Dashboard</h1>
+    <nav>
+        <ul>
+            <li><a href="habit.php">Habit Tracker</a></li>
+            <li><a href="calendar.php">Calendar</a></li>
+            <li><a href="timer.php">Timer</a></li>
+            <li><a href="goals.php">Goals</a></li>
+            <li><a href="journal.php">Journal</a></li>
+            <li><a href="meeting.php">Meeting Scheduler</a></li>
+        </ul>
+    </nav>
+</body>
+</html>

--- a/practice/php_productivity_dashboard/journal.php
+++ b/practice/php_productivity_dashboard/journal.php
@@ -1,0 +1,32 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('INSERT INTO journal_entries (entry) VALUES (:entry)');
+    $stmt->execute([':entry' => $_POST['entry'] ?? '']);
+}
+
+$entries = $pdo->query('SELECT * FROM journal_entries ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Journal</title>
+</head>
+<body>
+    <h1>Journal</h1>
+    <form method="post">
+        <textarea name="entry" rows="4" cols="50" placeholder="Write something..." required></textarea>
+        <br>
+        <button type="submit">Save Entry</button>
+    </form>
+    <?php foreach ($entries as $entry): ?>
+        <div>
+            <strong><?php echo htmlspecialchars($entry['created_at']); ?></strong>
+            <p><?php echo nl2br(htmlspecialchars($entry['entry'])); ?></p>
+        </div>
+        <hr>
+    <?php endforeach; ?>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>

--- a/practice/php_productivity_dashboard/meeting.php
+++ b/practice/php_productivity_dashboard/meeting.php
@@ -1,0 +1,37 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('INSERT INTO meetings (title, meeting_date, meeting_time, agenda) VALUES (:title, :meeting_date, :meeting_time, :agenda)');
+    $stmt->execute([
+        ':title' => $_POST['title'] ?? '',
+        ':meeting_date' => $_POST['meeting_date'] ?? '',
+        ':meeting_time' => $_POST['meeting_time'] ?? '',
+        ':agenda' => $_POST['agenda'] ?? ''
+    ]);
+}
+
+$meetings = $pdo->query('SELECT * FROM meetings ORDER BY meeting_date, meeting_time')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Meetings</title>
+</head>
+<body>
+    <h1>Meetings</h1>
+    <form method="post">
+        <input type="text" name="title" placeholder="Title" required>
+        <input type="date" name="meeting_date" required>
+        <input type="time" name="meeting_time" required>
+        <input type="text" name="agenda" placeholder="Agenda">
+        <button type="submit">Schedule Meeting</button>
+    </form>
+    <ul>
+        <?php foreach ($meetings as $meeting): ?>
+            <li><?php echo htmlspecialchars($meeting['meeting_date']); ?> <?php echo htmlspecialchars($meeting['meeting_time']); ?> - <?php echo htmlspecialchars($meeting['title']); ?>: <?php echo htmlspecialchars($meeting['agenda']); ?></li>
+        <?php endforeach; ?>
+    </ul>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>

--- a/practice/php_productivity_dashboard/timer.php
+++ b/practice/php_productivity_dashboard/timer.php
@@ -1,0 +1,35 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('INSERT INTO time_entries (task, minutes, entry_date) VALUES (:task, :minutes, :entry_date)');
+    $stmt->execute([
+        ':task' => $_POST['task'] ?? '',
+        ':minutes' => $_POST['minutes'] ?? 0,
+        ':entry_date' => $_POST['entry_date'] ?? ''
+    ]);
+}
+
+$entries = $pdo->query('SELECT * FROM time_entries ORDER BY entry_date DESC')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Timer</title>
+</head>
+<body>
+    <h1>Timer</h1>
+    <form method="post">
+        <input type="text" name="task" placeholder="Task" required>
+        <input type="number" name="minutes" placeholder="Minutes" required>
+        <input type="date" name="entry_date" required>
+        <button type="submit">Log Time</button>
+    </form>
+    <ul>
+        <?php foreach ($entries as $entry): ?>
+            <li><?php echo htmlspecialchars($entry['entry_date']); ?> - <?php echo htmlspecialchars($entry['task']); ?>: <?php echo htmlspecialchars($entry['minutes']); ?> mins</li>
+        <?php endforeach; ?>
+    </ul>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Productivty dashboard index and navigation
- implement Habit, Calendar, Timer, Goals, Journal, and Meeting modules with basic forms
- create SQLite-backed db.php with tables for all modules

## Testing
- `php -l practice/php_productivity_dashboard/index.php`
- `php -l practice/php_productivity_dashboard/db.php`
- `php -l practice/php_productivity_dashboard/habit.php`
- `php -l practice/php_productivity_dashboard/calendar.php`
- `php -l practice/php_productivity_dashboard/timer.php`
- `php -l practice/php_productivity_dashboard/goals.php`
- `php -l practice/php_productivity_dashboard/journal.php`
- `php -l practice/php_productivity_dashboard/meeting.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1134a22a8832f8a5809b6b2f0b9d8